### PR TITLE
Fix for Silverstripe 3.3 downloading resampled assets

### DIFF
--- a/code/SecureFileController.php
+++ b/code/SecureFileController.php
@@ -51,7 +51,7 @@ class SecureFileController extends Controller {
 
 			if ($self->canDownloadFile($file)) {
 				// If we're trying to access a resampled image.
-				if (preg_match('/_resampled\/[^-]+-/', $url)) {
+				if (preg_match('/_resampled\//', $url)) {
 					// File::find() will always return the original image, but we still want to serve the resampled version.
 					$file = new Image();
 					$file->Filename = $url;


### PR DESCRIPTION
Downloading resampled images in restricted folders didn't work correctly on silverstripe 3.3, see:
https://github.com/silverstripe/silverstripe-secureassets/issues/42

This fixes the issue and doesn't break previous versions, because the file will still be in the _resampled folder.