### PR TITLE
BUGFIX: Fixed crash on older versions of PHP when the file does not exist

### DIFF
--- a/code/SecureFileController.php
+++ b/code/SecureFileController.php
@@ -66,7 +66,7 @@ class SecureFileController extends Controller {
 					Security::permissionFailure($self, 'You are not authorised to access this resource. Please log in.');
 				} else {
 					// File doesn't exist
-					return $this->httpError(404);
+					return $self->httpError(404);
 				}
 			}
 


### PR DESCRIPTION
In legacy PHP versions (produced for sure in 5.3) if the file does not exist a fatal error is thrown "PHP Fatal error:  Using $this when not in object context in SecureFileController.php on line 69". This pull request changes the line to use the ``$self`` variable defined.