### PR TITLE
Use case-sensitive equivalent of File::find()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ matrix:
     - php: 5.6
       env: DB=MYSQL CORE_RELEASE=3
     - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.1
+      env: DB=MYSQL CORE_RELEASE=3.3
     - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.2
+      env: DB=PGSQL CORE_RELEASE=3.4
     - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.3 SUBSITES=1
+      env: DB=PGSQL CORE_RELEASE=3.5 SUBSITES=1
     - php: 7.1
       env: DB=MYSQL CORE_RELEASE=3.6
 

--- a/code/SecureFileController.php
+++ b/code/SecureFileController.php
@@ -225,7 +225,7 @@ class SecureFileController extends Controller {
             if($part == ASSETS_DIR && !$parentID) continue;
             /** @var File $item */
             $item = File::get()->filter(array(
-                'Name:ExactMatch' => $part,
+                'Name:ExactMatch:case' => $part,
                 'ParentID' => $parentID
             ))->first();
             if(!$item) break;

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "~3.1"
+        "silverstripe/framework": "^3.3"
     },
     "suggest": {
         "silverstripe/cms": "Allows you to easily edit file permissions in the CMS"


### PR DESCRIPTION
This has come up a few times already (#9, silverstripe/silverstripe-framework#3017, silverstripe/silverstripe-framework#6345).

Everything centres around the fact that SS should not allow files to be uploaded with the same filename but differing case (e.g. framework should not allow upload.jpg and Upload.jpg, one should be renamed).

However, there are many ways around this, as framework does not actively check - I believe `UploadField` now checks in the CMS context, but there's many other ways to get `File` objects into the database.

This PR is for the secureassets module to ensure that in the case of sensitive files in particular, we always show the correct file regardless of any bugs that framework has regarding allowing multiple files with the same name.